### PR TITLE
fix(creating-user): user logs out when a popup window is opened

### DIFF
--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -86,23 +86,44 @@ function hasOnlyGuestRole(data: BootstrapData) {
   return false;
 }
 
+const closeSession = async () => {
+  await fetch('/logout/', {
+    method: 'GET',
+    credentials: 'include',
+  });
+};
+
 const App = () => {
   useEffect(() => {
-    // Check if user exists and has the role "Guest"
-    if (hasOnlyGuestRole(bootstrapData)) {
-      // Send message to opener window
-      if (window.opener) {
-        window.opener.postMessage(
-          {
-            type: 'OAUTH2_SUCCESS',
-            data: {
-              // Add any additional data you need to send
-            },
-          },
-          '*',
-        );
+    const handleWindowOpen = async () => {
+      try {
+        // Check if the window was opened by another window
+        if (window.opener) {
+          // Verify if the user has only the "Guest" role
+          if (hasOnlyGuestRole(bootstrapData)) {
+            // Send a message to the opener window
+            window.opener.postMessage(
+              {
+                type: 'OAUTH2_SUCCESS',
+                data: {
+                  // Add any additional data to send
+                },
+              },
+              '*',
+            );
+          } else {
+            // Clear all cookies before proceeding
+            await closeSession();
+          }
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Error handling guest role:', error);
       }
-    }
+    };
+
+    // Call the async function
+    handleWindowOpen();
   }, []); // Empty dependency array means this runs once when component mounts
 
   return (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When trying to log in with a new user, as I had previously logged in with another user, the login in superset does not work. 
We resolved this by automatically logging out the currently logged in user whenever a popup window is opened

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
https://jira-datakimia.atlassian.net/browse/DP-413

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://jira-datakimia.atlassian.net/browse/DP-413
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
