### PR TITLE
Feat/dp 370 make the admin chart owners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,6 +141,7 @@ RUN apt-get update -qq \
         libxtst6 \
         git \
         pkg-config \
+        postgresql-client \
         && rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/docker/01-create-chart-ownership-trigger.sql
+++ b/docker/01-create-chart-ownership-trigger.sql
@@ -1,0 +1,28 @@
+-- First, create the trigger function
+CREATE OR REPLACE FUNCTION add_admin_role_function()
+RETURNS TRIGGER AS $$
+BEGIN
+
+    DELETE FROM slice_user
+    WHERE user_id IN (
+    SELECT user_id
+    FROM ab_user_role
+    WHERE role_id in (SELECT id FROM ab_role WHERE name = 'Admin' OR name = 'Client_Admin'));
+
+    INSERT INTO slice_user(user_id, slice_id)
+    SELECT user_id, NEW.id
+    FROM ab_user_role
+    WHERE role_id in (SELECT id FROM ab_role WHERE name = 'Admin' OR name = 'Client_Admin');
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Then, create the trigger using the function
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'add_admin_role') THEN
+        CREATE TRIGGER add_admin_role
+        AFTER INSERT OR UPDATE ON slices
+        FOR EACH ROW EXECUTE FUNCTION add_admin_role_function();
+    END IF;
+END $$;

--- a/docker/01-create-chart-ownership-trigger.sql
+++ b/docker/01-create-chart-ownership-trigger.sql
@@ -7,12 +7,12 @@ BEGIN
     WHERE user_id IN (
     SELECT user_id
     FROM ab_user_role
-    WHERE role_id in (SELECT id FROM ab_role WHERE name = 'Admin' OR name = 'Client_Admin'));
+    WHERE role_id in (SELECT id FROM ab_role WHERE name like '%Admin%'));
 
     INSERT INTO slice_user(user_id, slice_id)
     SELECT user_id, NEW.id
     FROM ab_user_role
-    WHERE role_id in (SELECT id FROM ab_role WHERE name = 'Admin' OR name = 'Client_Admin');
+    WHERE role_id in (SELECT id FROM ab_role WHERE name like '%Admin%');
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/docker/02-set-admins-as-chart-owners.sql
+++ b/docker/02-set-admins-as-chart-owners.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+DELETE FROM slice_user
+WHERE user_id IN (
+SELECT user_id
+FROM ab_user_role
+WHERE role_id in (SELECT id FROM ab_role WHERE name like '%Admin%'));
+
+INSERT INTO slice_user(user_id, slice_id)
+SELECT ur.user_id, s.id
+FROM ab_user_role ur, slices s
+WHERE ur.role_id in (SELECT id FROM ab_role WHERE name like '%Admin%');
+
+COMMIT;

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -79,8 +79,10 @@ fi
 
 echo_step "5" "Executing custom DB initilization scripts"
 source docker/.env
-# Path to the SQL script
-SQL_SCRIPT_PATH="/app/docker/01-create-chart-ownership-trigger.sql"
-# Execute the SQL script using psql
-PGPASSWORD=$DATABASE_PASSWORD psql -h $DATABASE_HOST -p $DATABASE_PORT -U $DATABASE_USER -d $DATABASE_DB -f $SQL_SCRIPT_PATH
+# Path to the SQL scripts
+SQL_SCRIPT_01_PATH="/app/docker/01-create-chart-ownership-trigger.sql"
+SQL_SCRIPT_02_PATH="/app/docker/02-set-admins-as-chart-owners.sql"
+# Execute the SQL scripts using psql
+PGPASSWORD=$DATABASE_PASSWORD psql -h $DATABASE_HOST -p $DATABASE_PORT -U $DATABASE_USER -d $DATABASE_DB -f $SQL_SCRIPT_01_PATH
+PGPASSWORD=$DATABASE_PASSWORD psql -h $DATABASE_HOST -p $DATABASE_PORT -U $DATABASE_USER -d $DATABASE_DB -f $SQL_SCRIPT_02_PATH
 echo_step "5" "Complete" "Executing custom DB initilization scripts"

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -76,3 +76,11 @@ if [ "$SUPERSET_LOAD_EXAMPLES" = "yes" ]; then
     fi
     echo_step "4" "Complete" "Loading examples"
 fi
+
+echo_step "5" "Executing custom DB initilization scripts"
+source docker/.env
+# Path to the SQL script
+SQL_SCRIPT_PATH="/app/docker/01-create-chart-ownership-trigger.sql"
+# Execute the SQL script using psql
+PGPASSWORD=$DATABASE_PASSWORD psql -h $DATABASE_HOST -p $DATABASE_PORT -U $DATABASE_USER -d $DATABASE_DB -f $SQL_SCRIPT_PATH
+echo_step "5" "Complete" "Executing custom DB initilization scripts"


### PR DESCRIPTION
SUMMARY
When a user creates a chart in superset and then adds it to a dashboard or even without adding it, and another user opens it and the other user modifies something, the second user, not being the owner of the dashboard, creates a new chart when he saves the change instead of saving the change and overwriting the chart.
This is because the second user is not the owner of the chart. Then something that we had thought that we do not know if it can be done is that for all dashboards created by any of the admins to fire a trigger to automatically make all other admin users owner of the charts.


TESTING INSTRUCTIONS
- Check every created chart has all the Admin users as owners
- Create a new chart and verify all the admin users are owners


ADDITIONAL INFORMATION
 Has associated issue: https://jira-datakimia.atlassian.net/browse/DP-370
 Required feature flags:
 Changes UI
 Includes DB Migration (follow approval process in https://github.com/apache/superset/issues/13351)
 Migration is atomic, supports rollback & is backwards-compatible
 Confirm DB migration upgrade and downgrade tested
 Runtime estimates and downtime expectations provided
 Introduces new feature or API
 Removes existing feature or API
