### PR TITLE
feat(filters-control): :sparkles: avoid change filters control when c…

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -220,7 +220,9 @@ const FilterControls: FC<FilterControlsProps> = ({
   );
 
   const items = useMemo(() => {
-    const crossFilters = selectedCrossFilters.map(c => ({
+    // DP-667: Cross filters are not being listened to and won't be displayed in FilterControl
+    // https://jira-datakimia.atlassian.net/browse/DP-667
+    /* const crossFilters = selectedCrossFilters.map(c => ({
       // a combination of filter name and chart id to account
       // for multiple cross filters from the same chart in the future
       id: `${c.name}${c.emitterId}`,
@@ -229,7 +231,7 @@ const FilterControls: FC<FilterControlsProps> = ({
         FilterBarOrientation.Horizontal,
         selectedCrossFilters.at(-1),
       ),
-    }));
+    })); */
     const nativeFiltersInScope = filtersInScope.map((filter, index) => ({
       id: filter.id,
       element: (
@@ -243,8 +245,8 @@ const FilterControls: FC<FilterControlsProps> = ({
         </div>
       ),
     }));
-    return [...crossFilters, ...nativeFiltersInScope];
-  }, [filtersInScope, renderer, rendererCrossFilter, selectedCrossFilters]);
+    return [...nativeFiltersInScope];
+  }, [filtersInScope, renderer]);
 
   const renderHorizontalContent = () => (
     <div
@@ -330,7 +332,6 @@ const FilterControls: FC<FilterControlsProps> = ({
       popoverRef?.current?.open();
     }
   }, [outlinedFilterId, lastUpdated, popoverRef, overflowedIds]);
-
   return (
     <>
       {portalNodes


### PR DESCRIPTION
### SUMMARY
Added documentation comments to clarify that cross filters functionality is intentionally disabled in the FilterControl component. The cross filters code is commented out and will not be displayed or listened to in the FilterControl, as referenced in JIRA ticket DP-667.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - This is a documentation-only change with no visual impact.

### TESTING INSTRUCTIONS
1. Navigate to a dashboard with native filters
2. Click in a table with activated cross filters
3. Verify that cross filters are not displayed in the filter bar
4. Confirm that the commented code block includes the explanatory comments referencing DP-667

### ADDITIONAL INFORMATION
- [x] Has associated issue: DP-667 (https://jira-datakimia.atlassian.net/browse/DP-667)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
